### PR TITLE
ipc: add a API to set socketDirectory

### DIFF
--- a/ipc/uapi_unix.go
+++ b/ipc/uapi_unix.go
@@ -27,6 +27,10 @@ const (
 // socketDirectory is variable because it is modified by a linker
 // flag in wireguard-android.
 var socketDirectory = "/var/run/amneziawg"
+// For android work profile
+func SetSocketDirectory(directory string) {
+	socketDirectory = directory
+}
 
 func sockPath(iface string) string {
 	return fmt.Sprintf("%s/%s.sock", socketDirectory, iface)


### PR DESCRIPTION
The same app installed in Android work profile will use a different cache directory, so I have to allow socketDirectory to be modified at runtime.