### PR TITLE
Fix build issues after upstream merge

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -130,23 +130,6 @@ type Device struct {
 
 	version Version
 	awg     awg.Protocol
-	isASecOn    abool.AtomicBool
-	aSecMux     sync.RWMutex
-	aSecCfg     aSecCfgType
-	junkCreator junkCreator
-}
-
-type aSecCfgType struct {
-	isSet                      bool
-	junkPacketCount            int
-	junkPacketMinSize          int
-	junkPacketMaxSize          int
-	initPacketJunkSize         int
-	responsePacketJunkSize     int
-	initPacketMagicHeader      uint32
-	responsePacketMagicHeader  uint32
-	underloadPacketMagicHeader uint32
-	transportPacketMagicHeader uint32
 }
 
 // deviceState represents the state of a Device.


### PR DESCRIPTION
## Summary
- remove leftover advanced-security fields from `Device`

## Testing
- `go build`
- `go test ./...` *(fails: `tun/netstack` and `device/awg` build errors)*

------
https://chatgpt.com/codex/tasks/task_e_686725526c54833385cd07966da37374