### PR TITLE
Backport some wireguard-go upstream fixes

### DIFF
--- a/device/noise-protocol.go
+++ b/device/noise-protocol.go
@@ -137,6 +137,22 @@ func (msg *MessageInitiation) unmarshal(b []byte) error {
 	return nil
 }
 
+func (msg *MessageInitiation) marshal(b []byte) error {
+	if len(b) != MessageInitiationSize {
+		return errMessageLengthMismatch
+	}
+
+	binary.LittleEndian.PutUint32(b, msg.Type)
+	binary.LittleEndian.PutUint32(b[4:], msg.Sender)
+	copy(b[8:], msg.Ephemeral[:])
+	copy(b[8+len(msg.Ephemeral):], msg.Static[:])
+	copy(b[8+len(msg.Ephemeral)+len(msg.Static):], msg.Timestamp[:])
+	copy(b[8+len(msg.Ephemeral)+len(msg.Static)+len(msg.Timestamp):], msg.MAC1[:])
+	copy(b[8+len(msg.Ephemeral)+len(msg.Static)+len(msg.Timestamp)+len(msg.MAC1):], msg.MAC2[:])
+
+	return nil
+}
+
 func (msg *MessageResponse) unmarshal(b []byte) error {
 	if len(b) != MessageResponseSize {
 		return errMessageLengthMismatch
@@ -153,6 +169,22 @@ func (msg *MessageResponse) unmarshal(b []byte) error {
 	return nil
 }
 
+func (msg *MessageResponse) marshal(b []byte) error {
+	if len(b) != MessageResponseSize {
+		return errMessageLengthMismatch
+	}
+
+	binary.LittleEndian.PutUint32(b, msg.Type)
+	binary.LittleEndian.PutUint32(b[4:], msg.Sender)
+	binary.LittleEndian.PutUint32(b[8:], msg.Receiver)
+	copy(b[12:], msg.Ephemeral[:])
+	copy(b[12+len(msg.Ephemeral):], msg.Empty[:])
+	copy(b[12+len(msg.Ephemeral)+len(msg.Empty):], msg.MAC1[:])
+	copy(b[12+len(msg.Ephemeral)+len(msg.Empty)+len(msg.MAC1):], msg.MAC2[:])
+
+	return nil
+}
+
 func (msg *MessageCookieReply) unmarshal(b []byte) error {
 	if len(b) != MessageCookieReplySize {
 		return errMessageLengthMismatch
@@ -162,6 +194,19 @@ func (msg *MessageCookieReply) unmarshal(b []byte) error {
 	msg.Receiver = binary.LittleEndian.Uint32(b[4:])
 	copy(msg.Nonce[:], b[8:])
 	copy(msg.Cookie[:], b[8+len(msg.Nonce):])
+
+	return nil
+}
+
+func (msg *MessageCookieReply) marshal(b []byte) error {
+	if len(b) != MessageCookieReplySize {
+		return errMessageLengthMismatch
+	}
+
+	binary.LittleEndian.PutUint32(b, msg.Type)
+	binary.LittleEndian.PutUint32(b[4:], msg.Receiver)
+	copy(b[8:], msg.Nonce[:])
+	copy(b[8+len(msg.Nonce):], msg.Cookie[:])
 
 	return nil
 }

--- a/device/noise-protocol.go
+++ b/device/noise-protocol.go
@@ -119,11 +119,11 @@ type MessageCookieReply struct {
 	Cookie   [blake2s.Size128 + poly1305.TagSize]byte
 }
 
-var errMessageTooShort = errors.New("message too short")
+var errMessageLengthMismatch = errors.New("message length mismatch")
 
 func (msg *MessageInitiation) unmarshal(b []byte) error {
-	if len(b) < MessageInitiationSize {
-		return errMessageTooShort
+	if len(b) != MessageInitiationSize {
+		return errMessageLengthMismatch
 	}
 
 	msg.Type = binary.LittleEndian.Uint32(b)
@@ -138,8 +138,8 @@ func (msg *MessageInitiation) unmarshal(b []byte) error {
 }
 
 func (msg *MessageResponse) unmarshal(b []byte) error {
-	if len(b) < MessageResponseSize {
-		return errMessageTooShort
+	if len(b) != MessageResponseSize {
+		return errMessageLengthMismatch
 	}
 
 	msg.Type = binary.LittleEndian.Uint32(b)
@@ -154,8 +154,8 @@ func (msg *MessageResponse) unmarshal(b []byte) error {
 }
 
 func (msg *MessageCookieReply) unmarshal(b []byte) error {
-	if len(b) < MessageCookieReplySize {
-		return errMessageTooShort
+	if len(b) != MessageCookieReplySize {
+		return errMessageLengthMismatch
 	}
 
 	msg.Type = binary.LittleEndian.Uint32(b)

--- a/device/noise-protocol.go
+++ b/device/noise-protocol.go
@@ -7,6 +7,7 @@ package device
 
 import (
 	"crypto/rand"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"sync"
@@ -116,6 +117,53 @@ type MessageCookieReply struct {
 	Receiver uint32
 	Nonce    [chacha20poly1305.NonceSizeX]byte
 	Cookie   [blake2s.Size128 + poly1305.TagSize]byte
+}
+
+var errMessageTooShort = errors.New("message too short")
+
+func (msg *MessageInitiation) unmarshal(b []byte) error {
+	if len(b) < MessageInitiationSize {
+		return errMessageTooShort
+	}
+
+	msg.Type = binary.LittleEndian.Uint32(b)
+	msg.Sender = binary.LittleEndian.Uint32(b[4:])
+	copy(msg.Ephemeral[:], b[8:])
+	copy(msg.Static[:], b[8+len(msg.Ephemeral):])
+	copy(msg.Timestamp[:], b[8+len(msg.Ephemeral)+len(msg.Static):])
+	copy(msg.MAC1[:], b[8+len(msg.Ephemeral)+len(msg.Static)+len(msg.Timestamp):])
+	copy(msg.MAC2[:], b[8+len(msg.Ephemeral)+len(msg.Static)+len(msg.Timestamp)+len(msg.MAC1):])
+
+	return nil
+}
+
+func (msg *MessageResponse) unmarshal(b []byte) error {
+	if len(b) < MessageResponseSize {
+		return errMessageTooShort
+	}
+
+	msg.Type = binary.LittleEndian.Uint32(b)
+	msg.Sender = binary.LittleEndian.Uint32(b[4:])
+	msg.Receiver = binary.LittleEndian.Uint32(b[8:])
+	copy(msg.Ephemeral[:], b[12:])
+	copy(msg.Empty[:], b[12+len(msg.Ephemeral):])
+	copy(msg.MAC1[:], b[12+len(msg.Ephemeral)+len(msg.Empty):])
+	copy(msg.MAC2[:], b[12+len(msg.Ephemeral)+len(msg.Empty)+len(msg.MAC1):])
+
+	return nil
+}
+
+func (msg *MessageCookieReply) unmarshal(b []byte) error {
+	if len(b) < MessageCookieReplySize {
+		return errMessageTooShort
+	}
+
+	msg.Type = binary.LittleEndian.Uint32(b)
+	msg.Receiver = binary.LittleEndian.Uint32(b[4:])
+	copy(msg.Nonce[:], b[8:])
+	copy(msg.Cookie[:], b[8+len(msg.Nonce):])
+
+	return nil
 }
 
 type Handshake struct {

--- a/device/receive.go
+++ b/device/receive.go
@@ -6,7 +6,6 @@
 package device
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"net"
@@ -327,8 +326,7 @@ func (device *Device) RoutineHandshake(id int) {
 			// unmarshal packet
 
 			var reply MessageCookieReply
-			reader := bytes.NewReader(elem.packet)
-			err := binary.Read(reader, binary.LittleEndian, &reply)
+			err := reply.unmarshal(elem.packet)
 			if err != nil {
 				device.log.Verbosef("Failed to decode cookie reply")
 				goto skip
@@ -397,8 +395,7 @@ func (device *Device) RoutineHandshake(id int) {
 		case MessageInitiationType:
 			// unmarshal
 			var msg MessageInitiation
-			reader := bytes.NewReader(elem.packet)
-			err := binary.Read(reader, binary.LittleEndian, &msg)
+			err := msg.unmarshal(elem.packet)
 			if err != nil {
 				device.log.Errorf("Failed to decode initiation message")
 				goto skip
@@ -432,8 +429,7 @@ func (device *Device) RoutineHandshake(id int) {
 			// unmarshal
 
 			var msg MessageResponse
-			reader := bytes.NewReader(elem.packet)
-			err := binary.Read(reader, binary.LittleEndian, &msg)
+			err := msg.unmarshal(elem.packet)
 			if err != nil {
 				device.log.Errorf("Failed to decode response message")
 				goto skip

--- a/device/send.go
+++ b/device/send.go
@@ -6,7 +6,6 @@
 package device
 
 import (
-	"bytes"
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
@@ -154,9 +153,8 @@ func (peer *Peer) SendHandshakeInitiation(isRetry bool) error {
 	crypt := buf[:padding]
 	rand.Read(crypt)
 
-	writer := bytes.NewBuffer(buf[padding:padding])
-	binary.Write(writer, binary.LittleEndian, msg)
-	packet := writer.Bytes()
+	packet := buf[padding : padding+MessageInitiationSize]
+	_ = msg.marshal(packet)
 	peer.cookieGenerator.AddMacs(packet)
 
 	peer.timersAnyAuthenticatedPacketTraversal()
@@ -204,9 +202,8 @@ func (peer *Peer) SendHandshakeResponse() error {
 	crypt := buf[:padding]
 	rand.Read(crypt)
 
-	writer := bytes.NewBuffer(buf[padding:padding])
-	binary.Write(writer, binary.LittleEndian, response)
-	packet := writer.Bytes()
+	packet := buf[padding : padding+MessageResponseSize]
+	_ = response.marshal(packet)
 	peer.cookieGenerator.AddMacs(packet)
 
 	err = peer.BeginSymmetricSession()
@@ -263,9 +260,8 @@ func (device *Device) SendHandshakeCookie(initiatingElem *QueueHandshakeElement)
 	crypt := buf[:padding]
 	rand.Read(crypt)
 
-	writer := bytes.NewBuffer(buf[padding:padding])
-	binary.Write(writer, binary.LittleEndian, reply)
-	packet := writer.Bytes()
+	packet := buf[padding : padding+MessageCookieReplySize]
+	_ = reply.marshal(packet)
 
 	cip, err := device.HeaderProtectionCipher(crypt[:HeaderCipherNonceSize])
 	if err != nil {

--- a/device/timers.go
+++ b/device/timers.go
@@ -23,6 +23,7 @@ type Timer struct {
 	modifyingLock sync.RWMutex
 	runningLock   sync.Mutex
 	duration      time.Duration
+	isPending     bool
 }
 
 func (peer *Peer) NewTimer(expirationFunction func(*Peer, time.Duration)) *Timer {
@@ -32,13 +33,13 @@ func (peer *Peer) NewTimer(expirationFunction func(*Peer, time.Duration)) *Timer
 		defer timer.runningLock.Unlock()
 
 		timer.modifyingLock.Lock()
-		if timer.duration == 0 {
+		if !timer.isPending {
 			timer.modifyingLock.Unlock()
 			return
 		}
 		duration := timer.duration
+		timer.isPending = false
 		timer.modifyingLock.Unlock()
-		timer.duration = 0
 
 		expirationFunction(peer, duration)
 	})
@@ -49,13 +50,14 @@ func (peer *Peer) NewTimer(expirationFunction func(*Peer, time.Duration)) *Timer
 func (timer *Timer) Mod(d time.Duration) {
 	timer.modifyingLock.Lock()
 	timer.duration = d
+	timer.isPending = true
 	timer.Reset(d)
 	timer.modifyingLock.Unlock()
 }
 
 func (timer *Timer) Del() {
 	timer.modifyingLock.Lock()
-	timer.duration = 0
+	timer.isPending = false
 	timer.Stop()
 	timer.modifyingLock.Unlock()
 }
@@ -70,7 +72,7 @@ func (timer *Timer) DelSync() {
 func (timer *Timer) IsPending() bool {
 	timer.modifyingLock.RLock()
 	defer timer.modifyingLock.RUnlock()
-	return timer.duration > 0
+	return timer.isPending
 }
 
 func (peer *Peer) timersActive() bool {

--- a/tun/offload_linux.go
+++ b/tun/offload_linux.go
@@ -608,6 +608,10 @@ func tcpGRO(bufs [][]byte, offset int, pktI int, table *tcpGROTable, isV6 bool) 
 			case coalesceItemInvalidCSum:
 				// delete the item with an invalid csum
 				table.deleteAt(item.key, i)
+				// The deleted item will not be re-visited in applyTCPCoalesceAccounting,
+				// so we must zero the virtioNetHdr. clear() is the equivalent of
+				// encoding a zero value virtioNetHdr.
+				clear(bufs[item.bufsIndex][offset-virtioNetHdrLen : offset])
 			case coalescePktInvalidCSum:
 				// no point in inserting an item that we can't coalesce
 				return groResultNoop
@@ -667,11 +671,7 @@ func applyTCPCoalesceAccounting(bufs [][]byte, offset int, table *tcpGROTable) e
 				psum := pseudoHeaderChecksumNoFold(unix.IPPROTO_TCP, srcAddr, dstAddr, uint16(len(pkt)-int(item.iphLen)))
 				binary.BigEndian.PutUint16(pkt[hdr.csumStart+hdr.csumOffset:], checksum([]byte{}, psum))
 			} else {
-				hdr := virtioNetHdr{}
-				err := hdr.encode(bufs[item.bufsIndex][offset-virtioNetHdrLen:])
-				if err != nil {
-					return err
-				}
+				clear(bufs[item.bufsIndex][offset-virtioNetHdrLen : offset])
 			}
 		}
 	}
@@ -727,11 +727,7 @@ func applyUDPCoalesceAccounting(bufs [][]byte, offset int, table *udpGROTable) e
 				psum := pseudoHeaderChecksumNoFold(unix.IPPROTO_UDP, srcAddr, dstAddr, uint16(len(pkt)-int(item.iphLen)))
 				binary.BigEndian.PutUint16(pkt[hdr.csumStart+hdr.csumOffset:], checksum([]byte{}, psum))
 			} else {
-				hdr := virtioNetHdr{}
-				err := hdr.encode(bufs[item.bufsIndex][offset-virtioNetHdrLen:])
-				if err != nil {
-					return err
-				}
+				clear(bufs[item.bufsIndex][offset-virtioNetHdrLen : offset])
 			}
 		}
 	}
@@ -880,11 +876,7 @@ func handleGRO(bufs [][]byte, offset int, tcpTable *tcpGROTable, udpTable *udpGR
 		}
 		switch result {
 		case groResultNoop:
-			hdr := virtioNetHdr{}
-			err := hdr.encode(bufs[i][offset-virtioNetHdrLen:])
-			if err != nil {
-				return err
-			}
+			clear(bufs[i][offset-virtioNetHdrLen : offset])
 			fallthrough
 		case groResultTableInsert:
 			*toWrite = append(*toWrite, i)

--- a/tun/offload_linux_test.go
+++ b/tun/offload_linux_test.go
@@ -750,3 +750,51 @@ func Test_udpPacketsCanCoalesce(t *testing.T) {
 		})
 	}
 }
+
+func Test_handleGRO_invalidItemCsumClearsVirtioNetHdr(t *testing.T) {
+	pkts := [][]byte{
+		flipTCP4Checksum(tcp4Packet(ip4PortA, ip4PortB, header.TCPFlagAck, 100, 1)),
+		tcp4Packet(ip4PortA, ip4PortB, header.TCPFlagAck, 100, 101),
+		tcp4Packet(ip4PortA, ip4PortB, header.TCPFlagAck, 100, 201),
+	}
+	// Poison the virtioNetHdr region of pkts[0] so a missing clear() is detectable.
+	for i := 0; i < virtioNetHdrLen; i++ {
+		pkts[0][i] = 0xAB
+	}
+
+	table := newTCPGROTable()
+	toWrite := make([]int, 0, len(pkts))
+	if err := handleGRO(pkts, virtioNetHdrLen, table, newUDPGROTable(), false, &toWrite); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify pkts[0] is in toWrite where we expect
+	if toWrite[0] != 0 {
+		t.Fatal("pkts[0] not found in toWrite at expected, zero index")
+	}
+
+	// Verify pkts[0] is not in tcpGROTable
+	if len(table.itemsByFlow) != 1 {
+		t.Fatalf("unexpected tcpGROTable items len: %d", len(table.itemsByFlow))
+	}
+	for _, v := range table.itemsByFlow {
+		if len(v) != 1 {
+			t.Fatalf("unexpected tcpGROItems slice len: %d", len(v))
+		}
+		item := v[0]
+		if item.sentSeq != 101 {
+			t.Fatalf("unexpected starting seq num in tcpGROTable: %d", item.sentSeq)
+		}
+		if item.numMerged != 1 {
+			t.Fatalf("unexpected numMerged in tcpGROTable: %d", item.numMerged)
+		}
+	}
+
+	// pkt 0 is in toWrite and not present in tcpGROTable, so its virtioNetHdr
+	// must have been cleared.
+	for i, b := range pkts[0][:virtioNetHdrLen] {
+		if b != 0 {
+			t.Fatalf("pkts[0] virtioNetHdr[%d] = 0x%x, want 0", i, b)
+		}
+	}
+}


### PR DESCRIPTION
"device: optimize message encoding" required some adaption for amneziawg-go, but everything else was trivially applied. This should allow us to benefit from some of the improvements to wireguard-go.